### PR TITLE
Clean up loading of state and some fixes to parameter order

### DIFF
--- a/block_problem.py
+++ b/block_problem.py
@@ -12,77 +12,113 @@ temp_start_stack = []
 final_state = final_state.split(" ")
 start_state = start_state.split(" ")
 
+# loop each tower in final state
 for i in range(len(final_state)):
-    # print len(final_state[i])
-    if len(final_state[i]) == 1:
-        temp_stack = {}
-        # ontable = "ontable("+final_state[i]+")"
-        # clear = "clear("+final_state[i]+ ")"
-        temp_stack.update([ ('type', 'action') , ('name', 'ontable') , ('params', final_state[i])] )
-        combine_tstack.append(temp_stack)
-        temp_stack = {}
-        temp_stack.update([('type', 'action'), ('name', 'clear'), ('params', final_state[i])])
-        combine_tstack.append(temp_stack)
+    # make this easier to refer
+    tower = final_state[i]
+    tower_height = len(tower)
+    # when tower has only 1 block
+    # this if part can be handled outside the loop
+    if tower_height == 1:
+        combine_tstack.append({
+          'type': "action",
+          'name': "ontable",
+          'params': tower[0]
+        })
+        #temp_stack = {}
+        #temp_stack.update([('type', 'action'), ('name', 'clear'), ('params', tower[0])])
+        combine_tstack.append({
+          'type': "action",
+          'name': "clear",
+          'params': tower[0]
+        })
     else:
-        for j in range(len(final_state[i])):
-            if j == 0:
-                temp_stack = {}
-                # clear = "clear(" + final_state[i][j] + ")"
-                temp_stack.update([('type', 'predicate'), ('name', 'on'),
-                                    ('params', final_state[i][j] + "," + final_state[i][j + 1])])
-                combine_tstack.append(temp_stack)
-                # on = "on("+final_state[i][j]+","+final_state[i][j+1]+")"
-                temp1_stack = {}
+        # handle bottom block
+        temp_stack = {
+          'type': "predicate",
+          'name': "ontable",
+          'params': tower[0]
+        }
+        # clear = "clear(" + tower[j] + ")"
+        combine_tstack.append(temp_stack)
+        # on = "on("+tower[j]+","+tower[j+1]+")"
+        
+        # handle top block
+        temp1_stack = {
+          'type': "predicate",
+          'name': "clear",
+          'params': tower[-1]
+        }
+        combine_tstack.append(temp1_stack)
 
-                temp1_stack.update([('type', 'predicate'), ('name', 'clear'), ('params', final_state[i][j])])
-                combine_tstack.append(temp1_stack)
-                # temp_stack.append(on)
-                # temp_stack.append(clear)
-            elif j != len(final_state[i])-1:
-                temp_stack = {}
-                # on = "on(" + final_state[i][j-1] + "," + final_state[i][j] + ")"
-                # ontable = ontable = "ontable("+final_state[i][j]+")"
-                temp_stack.update([('type', 'predicate'), ('name', 'on'),
-                                   ('params', final_state[i][j] + "," + final_state[i][j + 1])])
-                combine_tstack.append(temp_stack)
-            else:
-                temp1_stack = {}
-                temp1_stack.update([('type', 'predicate'), ('name', 'ontable'), ('params', final_state[i][j])])
-                combine_tstack.append(temp1_stack)
+        # loop each block in tower, excluding the first block
+        for j in range(1, len(tower)):
+          temp_stack = {
+            'type': "predicate",
+            'name': "on",
+            'params': tower[j] + "," + tower[j-1]
+          }
+          # on = "on(" + tower[j-1] + "," + tower[j] + ")"
+          # ontable = ontable = "ontable("+tower[j]+")"
+          combine_tstack.append(temp_stack)
 stack.append(combine_tstack)
 for i in combine_tstack:
     stack.append(i)
+
 temp_stack = {}
 temp1_stack = {}
-for i in range(len(start_state)):
-    if len(start_state[i]) == 1:
-        # ontable = "ontable("+start_state[i]+")"
-        # clear = "clear("+start_state[i]+ ")"
-        temp_stack = {}
-        temp_stack.update([('type', 'predicate'), ('name', 'ontable'), ('params', start_state[i])])
-        temp_start_stack.append(temp_stack)
-        temp_stack = {}
-        temp_stack.update([('type', 'predicate'), ('name', 'clear'), ('params', start_state[i])])
-        temp_start_stack.append(temp_stack)
 
+# loop each tower in start state
+for i in range(len(start_state)):
+    # make this easier to refer
+    tower = start_state[i]
+    tower_height = len(tower)
+    # when tower has only 1 block
+    # this if part can be handled outside the loop
+    if tower_height == 1:
+        temp_start_stack.append({
+          'type': "action",
+          'name': "ontable",
+          'params': tower[0]
+        })
+        #temp_stack = {}
+        #temp_stack.update([('type', 'action'), ('name', 'clear'), ('params', tower[0])])
+        temp_start_stack.append({
+          'type': "action",
+          'name': "clear",
+          'params': tower[0]
+        })
     else:
-        for j in range(len(start_state[i])):
-            if j == 0:
-                temp_stack = {}
-                temp_stack.update([('type', 'predicate'), ('name', 'clear'), ('params', start_state[i][j])])
-                temp_start_stack.append(temp_stack)
-                temp1_stack = {}
-                temp1_stack.update([('type', 'predicate'), ('name', 'on'),
-                                    ('params', start_state[i][j] + "," + start_state[i][j + 1])])
-                temp_start_stack.append(temp1_stack)
-            elif j == len(start_state[i])-1:
-                temp1_stack = {}
-                temp1_stack.update([('type', 'predicate'), ('name', 'ontable'), ('params', start_state[i][j])])
-                temp_start_stack.append(temp1_stack)
-            else:
-                temp_stack = {}
-                temp_stack.update([('type', 'predicate'), ('name', 'on'), ('params', start_state[i][j] + "," + start_state[i][j+1])])
-                temp_start_stack.append(temp_stack)
+        # handle bottom block
+        temp_stack = {
+          'type': "predicate",
+          'name': "ontable",
+          'params': tower[0]
+        }
+        # clear = "clear(" + tower[j] + ")"
+        temp_start_stack.append(temp_stack)
+        # on = "on("+tower[j]+","+tower[j+1]+")"
+        
+        # handle top block
+        temp1_stack = {
+          'type': "predicate",
+          'name': "clear",
+          'params': tower[-1]
+        }
+        temp_start_stack.append(temp1_stack)
+
+        # loop each block in tower, excluding the first block
+        for j in range(1, len(tower)):
+          temp_stack = {
+            'type': "predicate",
+            'name': "on",
+            'params': tower[j] + "," + tower[j-1]
+          }
+          # on = "on(" + tower[j-1] + "," + tower[j] + ")"
+          # ontable = ontable = "ontable("+tower[j]+")"
+          temp_start_stack.append(temp_stack)
+
+
 temp_stack = {}
 temp1_stack = {}
 counter = 0
@@ -102,7 +138,8 @@ counter_pickup  =0
 counter_putdown  =0
 counter_holding  =0
 if start_state == final_state:
-    print "No Change"
+    print ("No Change")
+
 while len(stack) > 0:
     if stack[-1] not in temp_start_stack:
         # print stack[-1]


### PR DESCRIPTION
Final state has problem
[{'params': '1,3', 'type': 'predicate', 'name': 'on'}, {'params': '1', 'type': 'predicate', 'name': 'clear'}, {'params': '3,2', 'type': 'predicate', 'name': 'on'}, {'params': '2', 'type': 'predicate', 'name': 'ontable'}]

on(1,3) - block 1 is on 3, seems wrong 
clear(1) is wrong
on(3,2) is wrong
basically most of the parameters are opposite

Start state has problem 
[{'params': '1', 'type': 'predicate', 'name': 'ontable'}, {'params': '1', 'type': 'predicate', 'name': 'clear'}, {'params': '2', 'type': 'predicate', 'name': 'clear'}, {'params': '2,3', 'type': 'predicate', 'name': 'on'}, {'params': '3', 'type': 'predicate', 'name': 'ontable'}]
Temp_start_Stack:  [{'params': '1', 'type': 'predicate', 'name': 'clear'}, {'params': '2', 'type': 'predicate', 'name': 'ontable'}, {'params': '3,2', 'type': 'predicate', 'name': 'on'}, {'params': '1,3', 'type': 'predicate', 'name': 'on'}]
ontable(3) is not true

Your steps seems wrong
<pre>
  3 
1 2
</pre>

unstack(2,3) - unstack 2 from 3
you cannot do that leh

[{'params': '2,3', 'type': 'action', 'name': 'unstack'}, {'params': '2', 'type': 'action', 'name': 'putdown'}, {'params': '3', 'type': 'action', 'name': 'pickup'}, {'params': '3,2', 'type': 'action', 'name': 'stack'}, {'params': '1,3', 'type': 'action', 'name': 'stack'}]

Summary your start and end has issues so it is very difficult to derive at a solution.
Your stack processing is a mess too, you should handle each type separately,
like
```
if (conjunctive predicates)  
  check each predicate
  if all satisfied
    pop
  else  
    add unsatisfied back to stack
elif (predicate)  
  if satisfied
    pop
  else
    add action and preconds
else (action)
  do action then pop
```

I have fixed the start and end state for you, you figure out the stack processing with your team